### PR TITLE
feat(mcp): Add pagination and summary_only mode to analyze_diff

### DIFF
--- a/src/mcp_server/formatting.rs
+++ b/src/mcp_server/formatting.rs
@@ -100,6 +100,245 @@ pub(super) fn format_diff_output(
     output
 }
 
+/// Format diff output with pagination support - TOON format
+/// Returns paginated file analysis with semantic summaries
+pub(super) fn format_diff_output_paginated(
+    working_dir: &Path,
+    base_ref: &str,
+    target_ref: &str,
+    changed_files: &[crate::git::ChangedFile],
+    offset: usize,
+    limit: usize,
+) -> String {
+    use std::collections::HashMap;
+
+    let total_files = changed_files.len();
+
+    // Apply pagination
+    let page_files: Vec<_> = changed_files
+        .iter()
+        .skip(offset)
+        .take(limit)
+        .collect();
+
+    let mut output = String::new();
+
+    // TOON header with pagination metadata
+    output.push_str("_type: analyze_diff\n");
+    output.push_str(&format!("base: \"{}\"\n", base_ref));
+    output.push_str(&format!("target: \"{}\"\n", target_ref));
+    output.push_str(&format!("total_files: {}\n", total_files));
+    output.push_str(&format!("showing: {}\n", page_files.len()));
+    output.push_str(&format!("offset: {}\n", offset));
+    output.push_str(&format!("limit: {}\n", limit));
+
+    // Pagination hint
+    if offset + page_files.len() < total_files {
+        output.push_str(&format!(
+            "next_offset: {} (use offset={} for next page)\n",
+            offset + page_files.len(),
+            offset + limit
+        ));
+    }
+
+    // Count change types for summary (BTreeMap for deterministic order)
+    let mut by_type: BTreeMap<&str, usize> = BTreeMap::new();
+    for f in changed_files {
+        *by_type.entry(f.change_type.as_str()).or_insert(0) += 1;
+    }
+    let type_summary: Vec<_> = by_type.iter()
+        .map(|(k, v)| format!("{}={}", k, v))
+        .collect();
+    output.push_str(&format!("changes: {}\n", type_summary.join(", ")));
+
+    if page_files.is_empty() {
+        if total_files == 0 {
+            output.push_str("\n_note: No files changed.\n");
+        } else {
+            output.push_str(&format!(
+                "\n_note: No files at offset {}. Total: {}.\n",
+                offset, total_files
+            ));
+        }
+        return output;
+    }
+
+    output.push_str(&format!("\nfiles[{}]:\n", page_files.len()));
+
+    // Format each file in the page
+    for changed_file in page_files {
+        let full_path = working_dir.join(&changed_file.path);
+
+        output.push_str(&format!(
+            "  {} [{}]\n",
+            changed_file.path,
+            changed_file.change_type.as_str()
+        ));
+
+        if changed_file.change_type == crate::git::ChangeType::Deleted {
+            output.push_str("    (deleted)\n");
+            continue;
+        }
+
+        let lang = match Lang::from_path(&full_path) {
+            Ok(l) => l,
+            Err(_) => {
+                output.push_str("    (unsupported)\n");
+                continue;
+            }
+        };
+
+        let source = match fs::read_to_string(&full_path) {
+            Ok(s) => s,
+            Err(_) => {
+                output.push_str("    (unreadable)\n");
+                continue;
+            }
+        };
+
+        match parse_and_extract(&full_path, &source, lang) {
+            Ok(summary) => {
+                // Indent the TOON output
+                let toon = encode_toon(&summary);
+                for line in toon.lines() {
+                    output.push_str(&format!("    {}\n", line));
+                }
+            }
+            Err(e) => {
+                output.push_str(&format!("    (error: {})\n", e));
+            }
+        }
+    }
+
+    output
+}
+
+/// Format diff summary only - compact overview without per-file details
+/// Returns aggregate statistics for large diffs
+pub(super) fn format_diff_summary(
+    working_dir: &Path,
+    base_ref: &str,
+    target_ref: &str,
+    changed_files: &[crate::git::ChangedFile],
+) -> String {
+    use std::collections::HashMap;
+
+    let mut output = String::new();
+
+    // TOON header
+    output.push_str("_type: analyze_diff_summary\n");
+    output.push_str(&format!("base: \"{}\"\n", base_ref));
+    output.push_str(&format!("target: \"{}\"\n", target_ref));
+    output.push_str(&format!("total_files: {}\n", changed_files.len()));
+
+    if changed_files.is_empty() {
+        output.push_str("_note: No files changed.\n");
+        return output;
+    }
+
+    // Count by change type (BTreeMap for deterministic order)
+    let mut by_type: BTreeMap<&str, usize> = BTreeMap::new();
+    for f in changed_files {
+        *by_type.entry(f.change_type.as_str()).or_insert(0) += 1;
+    }
+    let type_summary: Vec<_> = by_type.iter()
+        .map(|(k, v)| format!("{}={}", k, v))
+        .collect();
+    output.push_str(&format!("by_change_type: {}\n", type_summary.join(", ")));
+
+    // Count by language/extension
+    let mut by_lang: HashMap<String, usize> = HashMap::new();
+    for f in changed_files {
+        let full_path = working_dir.join(&f.path);
+        let lang_name = match Lang::from_path(&full_path) {
+            Ok(l) => format!("{:?}", l),
+            Err(_) => {
+                // Use extension as fallback
+                full_path
+                    .extension()
+                    .map(|e| e.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "other".to_string())
+            }
+        };
+        *by_lang.entry(lang_name).or_insert(0) += 1;
+    }
+    // Sort by count descending, take top 10
+    let mut lang_vec: Vec<_> = by_lang.iter().collect();
+    lang_vec.sort_by(|a, b| b.1.cmp(a.1));
+    let lang_summary: Vec<_> = lang_vec.iter()
+        .take(10)
+        .map(|(k, v)| format!("{}={}", k, v))
+        .collect();
+    output.push_str(&format!("by_language: {}\n", lang_summary.join(", ")));
+
+    // Group by module (directory)
+    let mut by_module: HashMap<String, usize> = HashMap::new();
+    for f in changed_files {
+        let module = std::path::Path::new(&f.path)
+            .parent()
+            .and_then(|p| p.to_str())
+            .map(|s| if s.is_empty() { "(root)" } else { s })
+            .unwrap_or("(root)")
+            .to_string();
+        *by_module.entry(module).or_insert(0) += 1;
+    }
+    // Sort by count descending, take top 10
+    let mut module_vec: Vec<_> = by_module.iter().collect();
+    module_vec.sort_by(|a, b| b.1.cmp(a.1));
+    let module_summary: Vec<_> = module_vec.iter()
+        .take(10)
+        .map(|(k, v)| format!("{} ({})", k, v))
+        .collect();
+    output.push_str(&format!("top_modules: {}\n", module_summary.join(", ")));
+
+    // Quick risk assessment based on file types and locations
+    let mut high_risk = 0;
+    let mut medium_risk = 0;
+    let mut low_risk = 0;
+
+    for f in changed_files {
+        let path_lower = f.path.to_lowercase();
+        // Check for security-sensitive patterns (more specific to avoid false positives)
+        let has_key_pattern = path_lower.contains("api_key")
+            || path_lower.contains("apikey")
+            || path_lower.contains("private_key")
+            || path_lower.contains("secret_key")
+            || path_lower.contains("encryption_key")
+            || path_lower.contains("/keys/")
+            || path_lower.ends_with("_key.rs")
+            || path_lower.ends_with("_key.ts")
+            || path_lower.ends_with("_key.py");
+        if path_lower.contains("auth")
+            || path_lower.contains("security")
+            || path_lower.contains("crypt")
+            || path_lower.contains("password")
+            || path_lower.contains("secret")
+            || has_key_pattern
+            || path_lower.contains(".env")
+        {
+            high_risk += 1;
+        } else if path_lower.contains("config")
+            || path_lower.contains("api")
+            || path_lower.contains("database")
+            || path_lower.contains("migration")
+            || path_lower.contains("schema")
+        {
+            medium_risk += 1;
+        } else {
+            low_risk += 1;
+        }
+    }
+    output.push_str(&format!(
+        "risk_estimate: high={}, medium={}, low={}\n",
+        high_risk, medium_risk, low_risk
+    ));
+
+    // Hint for getting details
+    output.push_str("\n_hint: Use limit/offset params to paginate file details, or omit summary_only for full analysis.\n");
+
+    output
+}
+
 /// Get the list of supported languages as a formatted string
 pub(super) fn get_supported_languages() -> String {
     let languages = vec![
@@ -1552,5 +1791,274 @@ mod tests {
         };
         assert_eq!(ctx.branch, "develop");
         assert_eq!(ctx.remote, Some("upstream".to_string()));
+    }
+
+    // ========================================================================
+    // format_diff_output_paginated Tests
+    // ========================================================================
+
+    fn make_changed_file(path: &str, change_type: crate::git::ChangeType) -> crate::git::ChangedFile {
+        crate::git::ChangedFile {
+            path: path.to_string(),
+            old_path: None,
+            change_type,
+        }
+    }
+
+    #[test]
+    fn test_format_diff_output_paginated_empty() {
+        let temp = tempfile::tempdir().unwrap();
+        let output = format_diff_output_paginated(
+            temp.path(),
+            "main",
+            "HEAD",
+            &[],
+            0,
+            20,
+        );
+
+        assert!(output.contains("_type: analyze_diff"));
+        assert!(output.contains("base: \"main\""));
+        assert!(output.contains("target: \"HEAD\""));
+        assert!(output.contains("total_files: 0"));
+        assert!(output.contains("showing: 0"));
+        assert!(output.contains("No files changed"));
+    }
+
+    #[test]
+    fn test_format_diff_output_paginated_single_file() {
+        let temp = tempfile::tempdir().unwrap();
+        // Create a simple TypeScript file to parse
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        std::fs::write(
+            temp.path().join("src/main.ts"),
+            "export function hello(): string { return 'hi'; }",
+        ).unwrap();
+
+        let files = vec![
+            make_changed_file("src/main.ts", crate::git::ChangeType::Modified),
+        ];
+
+        let output = format_diff_output_paginated(
+            temp.path(),
+            "main",
+            "HEAD",
+            &files,
+            0,
+            20,
+        );
+
+        assert!(output.contains("_type: analyze_diff"));
+        assert!(output.contains("total_files: 1"));
+        assert!(output.contains("showing: 1"));
+        assert!(output.contains("src/main.ts [modified]"));
+        // Should NOT have next_offset since all files fit
+        assert!(!output.contains("next_offset:"));
+    }
+
+    #[test]
+    fn test_format_diff_output_paginated_with_pagination() {
+        let temp = tempfile::tempdir().unwrap();
+        // Create multiple files
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        for i in 0..5 {
+            std::fs::write(
+                temp.path().join(format!("src/file{}.ts", i)),
+                format!("export function f{}(): number {{ return {}; }}", i, i),
+            ).unwrap();
+        }
+
+        let files: Vec<_> = (0..5)
+            .map(|i| make_changed_file(&format!("src/file{}.ts", i), crate::git::ChangeType::Added))
+            .collect();
+
+        // Request only 2 files at offset 0
+        let output = format_diff_output_paginated(
+            temp.path(),
+            "main",
+            "HEAD",
+            &files,
+            0,
+            2,
+        );
+
+        assert!(output.contains("total_files: 5"));
+        assert!(output.contains("showing: 2"));
+        assert!(output.contains("offset: 0"));
+        assert!(output.contains("limit: 2"));
+        assert!(output.contains("next_offset: 2"));
+        // Should contain first two files
+        assert!(output.contains("file0.ts"));
+        assert!(output.contains("file1.ts"));
+        // Should NOT contain later files
+        assert!(!output.contains("file4.ts"));
+    }
+
+    #[test]
+    fn test_format_diff_output_paginated_offset_at_end() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        std::fs::write(
+            temp.path().join("src/main.ts"),
+            "export function f(): void {}",
+        ).unwrap();
+
+        let files = vec![
+            make_changed_file("src/main.ts", crate::git::ChangeType::Modified),
+        ];
+
+        // Offset beyond available files
+        let output = format_diff_output_paginated(
+            temp.path(),
+            "main",
+            "HEAD",
+            &files,
+            10,
+            20,
+        );
+
+        assert!(output.contains("total_files: 1"));
+        assert!(output.contains("showing: 0"));
+        assert!(output.contains("No files at offset 10"));
+    }
+
+    #[test]
+    fn test_format_diff_output_paginated_deleted_file() {
+        let temp = tempfile::tempdir().unwrap();
+
+        let files = vec![
+            make_changed_file("src/deleted.ts", crate::git::ChangeType::Deleted),
+        ];
+
+        let output = format_diff_output_paginated(
+            temp.path(),
+            "main",
+            "HEAD",
+            &files,
+            0,
+            20,
+        );
+
+        assert!(output.contains("src/deleted.ts [deleted]"));
+        assert!(output.contains("(deleted)"));
+    }
+
+    #[test]
+    fn test_format_diff_output_paginated_change_type_summary() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        std::fs::write(temp.path().join("src/a.ts"), "// a").unwrap();
+        std::fs::write(temp.path().join("src/b.ts"), "// b").unwrap();
+
+        let files = vec![
+            make_changed_file("src/a.ts", crate::git::ChangeType::Added),
+            make_changed_file("src/b.ts", crate::git::ChangeType::Modified),
+            make_changed_file("src/c.ts", crate::git::ChangeType::Deleted),
+        ];
+
+        let output = format_diff_output_paginated(
+            temp.path(),
+            "main",
+            "HEAD",
+            &files,
+            0,
+            20,
+        );
+
+        // Should have change type counts in summary
+        assert!(output.contains("changes:"));
+        assert!(output.contains("added=1"));
+        assert!(output.contains("modified=1"));
+        assert!(output.contains("deleted=1"));
+    }
+
+    // ========================================================================
+    // format_diff_summary Tests
+    // ========================================================================
+
+    #[test]
+    fn test_format_diff_summary_empty() {
+        let temp = tempfile::tempdir().unwrap();
+        let output = format_diff_summary(
+            temp.path(),
+            "main",
+            "HEAD",
+            &[],
+        );
+
+        assert!(output.contains("_type: analyze_diff_summary"));
+        assert!(output.contains("total_files: 0"));
+        assert!(output.contains("No files changed"));
+    }
+
+    #[test]
+    fn test_format_diff_summary_multiple_types() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        std::fs::write(temp.path().join("src/app.ts"), "// ts").unwrap();
+        std::fs::write(temp.path().join("src/lib.rs"), "// rs").unwrap();
+
+        let files = vec![
+            make_changed_file("src/app.ts", crate::git::ChangeType::Added),
+            make_changed_file("src/app.ts", crate::git::ChangeType::Added),
+            make_changed_file("src/lib.rs", crate::git::ChangeType::Modified),
+        ];
+
+        let output = format_diff_summary(
+            temp.path(),
+            "main",
+            "HEAD",
+            &files,
+        );
+
+        assert!(output.contains("_type: analyze_diff_summary"));
+        assert!(output.contains("total_files: 3"));
+        assert!(output.contains("by_change_type:"));
+        assert!(output.contains("by_language:"));
+        assert!(output.contains("top_modules:"));
+    }
+
+    #[test]
+    fn test_format_diff_summary_risk_assessment() {
+        let temp = tempfile::tempdir().unwrap();
+
+        let files = vec![
+            make_changed_file("src/auth/login.ts", crate::git::ChangeType::Modified),
+            make_changed_file("src/api/handler.ts", crate::git::ChangeType::Modified),
+            make_changed_file("src/utils/format.ts", crate::git::ChangeType::Modified),
+        ];
+
+        let output = format_diff_summary(
+            temp.path(),
+            "main",
+            "HEAD",
+            &files,
+        );
+
+        assert!(output.contains("risk_estimate:"));
+        // auth file should be high risk
+        assert!(output.contains("high=1"));
+        // api file should be medium risk
+        assert!(output.contains("medium=1"));
+        // utils file should be low risk
+        assert!(output.contains("low=1"));
+    }
+
+    #[test]
+    fn test_format_diff_summary_hint() {
+        let temp = tempfile::tempdir().unwrap();
+        let files = vec![
+            make_changed_file("file.ts", crate::git::ChangeType::Added),
+        ];
+
+        let output = format_diff_summary(
+            temp.path(),
+            "main",
+            "HEAD",
+            &files,
+        );
+
+        assert!(output.contains("_hint:"));
+        assert!(output.contains("limit/offset"));
     }
 }

--- a/src/mcp_server/instructions_fast.rs
+++ b/src/mcp_server/instructions_fast.rs
@@ -34,6 +34,8 @@ pub(super) const MCP_INSTRUCTIONS: &str = r#"MCP Semantic Diff - Code Analysis f
 
 ### Code Review
 1. `analyze_diff(base_ref: "main")` → changes
+   - For large PRs (50+ files): use `summary_only: true` first (~300 tokens)
+   - Then paginate: `limit: 20, offset: 0` to review in batches
 2. For risky: `get_callers(hash)` → impact
 **Skip get_overview** - diff independent!
 
@@ -44,6 +46,8 @@ pub(super) const MCP_INSTRUCTIONS: &str = r#"MCP Semantic Diff - Code Analysis f
 | get_context | ~200 | Always first |
 | get_overview | ~1-2k | Only for audits/module names |
 | search | ~500-1k | Auto-refreshes index |
+| analyze_diff(summary_only) | ~300 | Quick PR overview |
+| analyze_diff(paginated) | ~2-5k/page | Use limit/offset for large diffs |
 | get_callgraph(summary) | ~300 | Coupling overview |
 | validate | ~1-2k | Requires scope |
 | get_callers | ~500 | Before any changes |

--- a/src/mcp_server/types.rs
+++ b/src/mcp_server/types.rs
@@ -58,6 +58,18 @@ pub struct AnalyzeDiffRequest {
     /// Working directory (defaults to current directory)
     #[schemars(description = "Working directory for git operations (defaults to current directory)")]
     pub working_dir: Option<String>,
+
+    /// Maximum files to return per page (default: 20, max: 100)
+    #[schemars(description = "Maximum files to return per page (default: 20, max: 100)")]
+    pub limit: Option<usize>,
+
+    /// Skip first N files for pagination (default: 0)
+    #[schemars(description = "Skip first N files for pagination (default: 0)")]
+    pub offset: Option<usize>,
+
+    /// Return summary statistics only without per-file details (default: false)
+    #[schemars(description = "Return only summary statistics (file counts, risk breakdown, top modules) without per-file details. Use for large diffs to get overview first.")]
+    pub summary_only: Option<bool>,
 }
 
 /// Request to get supported languages


### PR DESCRIPTION
## Summary

Adds token optimization features to the MCP `analyze_diff` tool for handling large diffs that previously exceeded context limits (77 files → 313,963 chars).

### New Parameters
| Parameter | Default | Max | Description |
|-----------|---------|-----|-------------|
| `limit` | 20 | 100 | Files per page |
| `offset` | 0 | - | Skip first N files for pagination |
| `summary_only` | false | - | Return compact stats only |

### Token Reduction
- **`summary_only=true`**: >95% reduction (~300 tokens vs 15,000+)
- **Pagination**: ~67% reduction per page (review files in batches)

### Usage Examples
```
# Quick overview for large PRs
analyze_diff(base_ref: "main", summary_only: true)
→ Returns: total_files, by_change_type, by_language, top_modules, risk_estimate

# Paginated review
analyze_diff(base_ref: "main", limit: 20, offset: 0)
analyze_diff(base_ref: "main", limit: 20, offset: 20)  # next page
```

### Changes
- `types.rs`: Added `limit`, `offset`, `summary_only` to `AnalyzeDiffRequest`
- `formatting.rs`: Added `format_diff_output_paginated()` and `format_diff_summary()` + 10 unit tests
- `mod.rs`: Updated handler routing logic
- `instructions_fast.rs`: Documented new parameters and token costs

## Test plan
- [x] All 10 new unit tests pass (`cargo test`)
- [x] Production build succeeds (`cargo build --release`)
- [x] MCP tool tested with `summary_only=true` - returns compact summary
- [x] MCP tool tested with `limit=1` - returns paginated output with `next_offset`
- [x] Existing analyze_diff behavior unchanged when no params provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)